### PR TITLE
Loading rr graph nodes directions

### DIFF
--- a/rr_graph/graph2.py
+++ b/rr_graph/graph2.py
@@ -327,12 +327,12 @@ class Graph(object):
             assert key not in self.loc_map
             self.loc_map[key] = loc
 
-            for pin_class_idx, pin_class in enumerate(block_type.pin_class):
-                # Skip building IPIN -> SINK and OPIN -> SOURCE graph if edges
-                # are not required.
-                if not build_pin_edges:
-                    continue
+            # Skip building IPIN -> SINK and OPIN -> SOURCE graph if edges
+            # are not required.
+            if not build_pin_edges:
+                continue
 
+            for pin_class_idx, pin_class in enumerate(block_type.pin_class):
                 pin_class_node = self.loc_pin_class_map[
                     (loc.x, loc.y, pin_class_idx)]
 

--- a/rr_graph/tests/test_graph2.py
+++ b/rr_graph/tests/test_graph2.py
@@ -84,8 +84,6 @@ class Graph2Tests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
             Node(
                 id=1,
@@ -103,8 +101,6 @@ class Graph2Tests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
             Node(
                 id=2,
@@ -122,8 +118,6 @@ class Graph2Tests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
             Node(
                 id=3,
@@ -141,8 +135,6 @@ class Graph2Tests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
         ]
 
@@ -307,8 +299,6 @@ class Graph2MediumTests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
             Node(
                 id=1,
@@ -326,8 +316,6 @@ class Graph2MediumTests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
             Node(
                 id=2,
@@ -345,8 +333,6 @@ class Graph2MediumTests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
             Node(
                 id=3,
@@ -364,8 +350,6 @@ class Graph2MediumTests(unittest.TestCase):
                 timing=node_timing,
                 metadata=None,
                 segment=NodeSegment(segment_id=0),
-                canonical_loc=None,
-                connection_box=None,
             ),
         ]
 

--- a/rr_graph_capnp/graph2.py
+++ b/rr_graph_capnp/graph2.py
@@ -190,8 +190,6 @@ def read_node(node, new_node_id=None):
         timing=graph2.NodeTiming(r=node_timing.r, c=node_timing.c),
         metadata=None,
         segment=graph2.NodeSegment(segment_id=node.segment.segmentId),
-        canonical_loc=None,
-        connection_box=None
     )
 
 
@@ -340,24 +338,6 @@ class Graph(object):
             out_y_list.index = y_list.index
             out_y_list.info = y_list.info
 
-    def _write_connection_box(self, rr_graph, connection_box):
-        """
-        Writes the RR graph connection box.
-        """
-
-        rr_graph.connectionBoxes.xDim = connection_box.x_dim
-        rr_graph.connectionBoxes.yDim = connection_box.y_dim
-        rr_graph.connectionBoxes.numBoxes = len(connection_box.boxes)
-
-        connection_boxes = rr_graph.connectionBoxes.init(
-            'connectionBoxes', len(connection_box.boxes)
-        )
-
-        for idx, (out_box, box) in enumerate(zip(connection_boxes,
-                                                 connection_box.boxes)):
-            out_box.id = idx
-            out_box.name = box
-
     def _write_nodes(self, rr_graph, num_nodes, nodes, node_remap):
         """ Serialize list of Node objects to capnp.
 
@@ -413,18 +393,6 @@ class Graph(object):
                 for out_meta, meta in zip(metas, node.metadata):
                     out_meta.name = meta.name
                     out_meta.value = meta.value
-
-            if node.canonical_loc is not None:
-                canonical_loc = out_node.canonicalLoc
-                canonical_loc.x = node.canonical_loc.x
-                canonical_loc.y = node.canonical_loc.y
-
-            if node.connection_box is not None:
-                connection_box = out_node.connectionBox
-                connection_box.id = node.connection_box.id
-                connection_box.x = node.connection_box.x
-                connection_box.y = node.connection_box.y
-                connection_box.sitePinDelay = node.connection_box.site_pin_delay
 
         assert nodes_written == num_nodes, 'Unwritten nodes!'
 
@@ -558,7 +526,6 @@ class Graph(object):
     def serialize_to_capnp(
             self,
             channels_obj,
-            connection_box_obj,
             num_nodes,
             nodes_obj,
             num_edges,
@@ -581,7 +548,6 @@ class Graph(object):
         self._write_segments(rr_graph)
         self._write_block_types(rr_graph)
         self._write_grid(rr_graph)
-        self._write_connection_box(rr_graph, connection_box_obj)
         self._write_nodes(rr_graph, num_nodes, nodes_obj, node_remap)
         self._write_edges(rr_graph, num_edges, edges_obj, node_remap)
 

--- a/rr_graph_xml/graph2.py
+++ b/rr_graph_xml/graph2.py
@@ -256,8 +256,6 @@ def graph_from_xml(
                     timing=node_timing,
                     metadata=metadata,
                     segment=node_segment,
-                    canonical_loc=None,
-                    connection_box=None,
                 )
             )
 
@@ -419,25 +417,6 @@ class Graph(object):
 
         self._end_xml_tag()
 
-    def _write_connection_box(self, connection_box):
-        """
-        Writes the RR graph connection box.
-        """
-        attrib = {
-            "x_dim": connection_box.x_dim,
-            "y_dim": connection_box.y_dim,
-            "num_boxes": len(connection_box.boxes)
-        }
-
-        self._begin_xml_tag("connection_boxes", attrib)
-
-        for idx, box in enumerate(connection_box.boxes):
-            self._write_xml_tag("connection_box", {"id": idx, "name": box})
-            if DEBUG >= 2:
-                break
-
-        self._end_xml_tag()
-
     def _write_nodes(self, nodes, node_remap):
         """ Serialize list of Node objects to XML.
 
@@ -492,22 +471,6 @@ class Graph(object):
             if node.segment is not None:
                 attrib = {"segment_id": node.segment.segment_id}
                 self._write_xml_tag("segment", attrib)
-
-            if node.connection_box is not None:
-                attrib = {
-                    "x": node.connection_box.x,
-                    "y": node.connection_box.y,
-                    "id": node.connection_box.id,
-                    "site_pin_delay": node.connection_box.site_pin_delay,
-                }
-                self._write_xml_tag("connection_box", attrib)
-
-            if node.canonical_loc is not None:
-                attrib = {
-                    "x": node.canonical_loc.x,
-                    "y": node.canonical_loc.y,
-                }
-                self._write_xml_tag("canonical_loc", attrib)
 
             self._end_xml_tag()
             if DEBUG >= 2:
@@ -674,7 +637,6 @@ class Graph(object):
     def serialize_to_xml(
             self,
             channels_obj,
-            connection_box_obj,
             nodes_obj,
             edges_obj,
             node_remap=lambda x: x
@@ -694,9 +656,6 @@ class Graph(object):
             self._write_xml_header()
 
             self._write_channels(channels_obj)
-
-            if connection_box_obj is not None:
-                self._write_connection_box(connection_box_obj)
 
             self._write_switches()
             self._write_segments()

--- a/rr_graph_xml/graph2.py
+++ b/rr_graph_xml/graph2.py
@@ -73,6 +73,14 @@ def graph_from_xml(
     nodes = []
     edges = []
 
+    # Node direction map
+    node_direction_map = {
+        None: graph2.NodeDirection.NO_DIR,
+        "INC_DIR": graph2.NodeDirection.INC_DIR,
+        "DEC_DIR": graph2.NodeDirection.DEC_DIR,
+        "BI_DIR": graph2.NodeDirection.BI_DIR,
+    }
+
     # Itertate over XML elements
     switch_timing = None
     switch_sizing = None
@@ -232,6 +240,9 @@ def graph_from_xml(
             ]:
                 continue
 
+            direction = element.get("direction", None)
+            direction = node_direction_map[direction]
+
             # Dropping metadata for now
             metadata = None
 
@@ -239,7 +250,7 @@ def graph_from_xml(
                 graph2.Node(
                     id=int(element.attrib['id']),
                     type=node_type,
-                    direction=graph2.NodeDirection.NO_DIR,
+                    direction=direction,
                     capacity=int(element.attrib['capacity']),
                     loc=node_loc,
                     timing=node_timing,
@@ -286,6 +297,7 @@ class Graph(object):
             build_pin_edges=True,
             rebase_nodes=True,
             filter_nodes=True,
+            load_edges=False,
     ):
         if progressbar is None:
             progressbar = lambda x: x  # noqa: E731
@@ -295,7 +307,10 @@ class Graph(object):
         self.output_file_name = output_file_name
 
         graph_input = graph_from_xml(
-            input_file_name, progressbar, filter_nodes=filter_nodes
+            input_file_name,
+            progressbar,
+            filter_nodes=filter_nodes,
+            load_edges=load_edges,
         )
         graph_input['build_pin_edges'] = build_pin_edges
 


### PR DESCRIPTION
This PR adds reading of VPR node directions to the rr graph XML handling library. It also exposes the `load_edges` option. It also removes support for node canonical locations and connections boxes as they are no longer needed by SymbiFlow.